### PR TITLE
fix: issues-13 Missing Audiot Output in sinks on macOS

### DIFF
--- a/macos/bundle_utils.sh
+++ b/macos/bundle_utils.sh
@@ -67,39 +67,46 @@ bundle_get_exec_rpaths() {
 
 # bundle_find_full_path [dep_path] [exec_rpaths]
 bundle_find_full_path() {
-    # If path is relative to rpath, find the full path
-    local IS_RPATH_RELATIVE=$(echo $1 | grep @rpath/)
-    if [ "$IS_RPATH_RELATIVE" = "" ]; then
-        echo $1
-        return
-    fi
+    # Absolute (non-@rpath) reference: use it as-is.
+    case "$1" in
+        @rpath/*) ;;
+        *) echo "$1"; return ;;
+    esac
 
-    local RPATH_NEXT=$(echo $1 | cut -c 8-)
+    local RPATH_NEXT=${1#@rpath/}
 
-    # Search in the exec's RPATH
-    echo "$2" | while read -r RPATH; do
-        # If not found, skip
-        if [ ! -f $RPATH/$RPATH_NEXT ]; then
-            continue
+    # Search the binary's own rpaths. NOTE: this must NOT be a
+    # `echo "$2" | while read` pipeline — the pipe runs the loop in a
+    # subshell, so `return` there only exits the subshell and the function
+    # falls through to the final `echo "$1"` below, emitting a second
+    # (spurious) line. Callers capture the output unquoted, so that extra
+    # line word-splits into an extra argument and breaks bundle_install_binary's
+    # `[ $# -ne 3 ]` guard, silently dropping every @rpath dependency from the
+    # bundle. Iterate with a plain `for` over newline-split rpaths instead.
+    local OLDIFS=$IFS
+    IFS='
+'
+    for RPATH in $2; do
+        if [ -f "$RPATH/$RPATH_NEXT" ]; then
+            IFS=$OLDIFS
+            echo "$RPATH/$RPATH_NEXT"
+            return
         fi
-
-        # Correct dep path
-        echo $RPATH/$RPATH_NEXT
-        return -1
     done
+    IFS=$OLDIFS
 
     # Search other common paths
-    if [ -f /usr/local/lib/$RPATH_NEXT ]; then
-        echo /usr/local/lib/$RPATH_NEXT 
+    if [ -f "/usr/local/lib/$RPATH_NEXT" ]; then
+        echo "/usr/local/lib/$RPATH_NEXT"
         return
     fi
-    if [ -f /Library/Frameworks/$RPATH_NEXT ]; then
-        echo /Library/Frameworks/$RPATH_NEXT 
+    if [ -f "/Library/Frameworks/$RPATH_NEXT" ]; then
+        echo "/Library/Frameworks/$RPATH_NEXT"
         return
     fi
 
     # Not found, give up
-    echo $1
+    echo "$1"
 }
 
 # ========================= Public Functions =========================
@@ -157,11 +164,11 @@ bundle_install_binary() {
             continue
         fi
 
-        local DEP_PATH=$(bundle_find_full_path $DEP $RPATHS)
+        local DEP_PATH=$(bundle_find_full_path "$DEP" "$RPATHS")
 
         # If the dependency is not installed, install it
-        if [ ! -f $1/Contents/Frameworks/$DEP_NAME ]; then
-            bundle_install_binary $1 $1/Contents/Frameworks $DEP_PATH
+        if [ ! -f "$1/Contents/Frameworks/$DEP_NAME" ]; then
+            bundle_install_binary "$1" "$1/Contents/Frameworks" "$DEP_PATH"
         fi
 
         # Fix path


### PR DESCRIPTION
**Summary**

On macOS none of the system audio output devices show up in "Sinks", so there is no  
way to route demodulated audio to speakers or an interface. The cause is in the macOS  
bundling step: `@rpath`-based dependencies were never copied into the app bundle, so the  
PortAudio audio sink failed to `dlopen` (`Library not loaded: @rpath/libportaudio.dylib`)  
and its "Audio" provider was never registered. This PR fixes the bundler so all `@rpath`  
dependencies are staged correctly.

**Changes**

- **Dependency resolver** (`bundle_utils.sh`): rewrites `bundle_find_full_path`. It  
resolved `@rpath/...` deps inside an `echo "$2" | while read` pipeline, where `return`  
only exits the subshell - the function then fell through to the final `echo "$1"` and  
emitted a second, spurious `@rpath/...` line. Callers capture that output unquoted, so  
the extra token word-split into an additional argument and tripped  
`bundle_install_binary`'s `[ $# -ne 3 ]` guard, silently skipping the copy. Replaced the  
pipeline with a plain `for` loop over the newline-split rpaths so `return` exits the  
function and exactly one path is emitted.
- **Argument quoting** (`bundle_utils.sh`): quotes the dependency path and bundle  
arguments in `bundle_install_binary` so paths can no longer word-split.

**Testing**

- Re-staged the macOS bundle (`cmake --build build --target stage_macos_bundle`) and  
confirmed `libportaudio.dylib` is now copied into `Contents/Frameworks/`.
- Launched the bundled app and verified the audio sink modules load with no  
`Library not loaded` errors, so the "Audio" sink provider registers and system output  
devices appear in "Sinks".
- Side effect: the same fix restores bundling of other `@rpath` deps (e.g. `libusb`,  
`libhackrf`) that were previously dropped, for source plugins whose deps are built.

<img width="390" height="162" alt="Screenshot 2026-07-07 at 08 44 21" src="https://github.com/user-attachments/assets/1675f042-3918-471c-b58a-c2c953656bcc" />

This PR fixes problem reported in https://github.com/bubnikv/SDRPlusPlus-iak/issues/14
