### PR TITLE
Fix SpyServer and SDR++ Server connection hangs

### DIFF
--- a/core/src/utils/net.cpp
+++ b/core/src/utils/net.cpp
@@ -1,7 +1,9 @@
 #include "net.h"
+#include "net_resolve.h"
 #include <string.h>
 #include <codecvt>
 #include <stdexcept>
+#include <chrono>
 
 #ifdef _WIN32
 #define WOULD_BLOCK (WSAGetLastError() == WSAEWOULDBLOCK)
@@ -15,24 +17,23 @@
 #endif
 
 namespace net {
-    bool _init = false;
+    std::once_flag initFlag;
     
     // === Private functions ===
 
     void init() {
-        if (_init) { return; }
+        std::call_once(initFlag, []() {
 #ifdef _WIN32
-        // Initialize WinSock2
-        WSADATA wsa;
-        if (WSAStartup(MAKEWORD(2, 2), &wsa)) {
-            throw std::runtime_error("Could not initialize WinSock2");
-            return;
-        }
+            // Initialize WinSock2
+            WSADATA wsa;
+            if (WSAStartup(MAKEWORD(2, 2), &wsa)) {
+                throw std::runtime_error("Could not initialize WinSock2");
+            }
 #else
-        // Disable SIGPIPE to avoid closing when the remote host disconnects
-        signal(SIGPIPE, SIG_IGN);
+            // Disable SIGPIPE to avoid closing when the remote host disconnects
+            signal(SIGPIPE, SIG_IGN);
 #endif
-        _init = true;
+        });
     }
 
     bool queryHost(uint32_t* addr, std::string host) {
@@ -425,44 +426,101 @@ namespace net {
     }
 
     std::shared_ptr<Socket> connect(const Address& addr) {
+        return connect(addr, NO_TIMEOUT);
+    }
+
+    std::shared_ptr<Socket> connect(const Address& addr, int timeout) {
         // Init library if needed
         init();
 
         // Create socket
         SockHandle_t s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
-        // A blocking connect can take minutes on an unreachable address.  This
-        // function is used from source-module menu handlers, so keep the UI
-        // responsive by making the connection attempt non-blocking and waiting
-        // for a bounded time instead.
-        setNonblocking(s);
-
-        int result = ::connect(s, (sockaddr*)&addr.addr, sizeof(sockaddr_in));
+        if (timeout < 0) {
+            if (::connect(s, (sockaddr*)&addr.addr, sizeof(sockaddr_in))) {
 #ifdef _WIN32
-        if (result && WSAGetLastError() != WSAEWOULDBLOCK && WSAGetLastError() != WSAEINPROGRESS) {
+                int connectError = WSAGetLastError();
+                closeSocket(s);
+                throw std::runtime_error("Could not connect (error " + std::to_string(connectError) + ")");
 #else
-        if (result && errno != EINPROGRESS && errno != EWOULDBLOCK) {
+                int connectError = errno;
+                closeSocket(s);
+                throw std::runtime_error(std::string("Could not connect: ") + strerror(connectError));
 #endif
-            closeSocket(s);
-            throw std::runtime_error("Could not connect");
+            }
+            setNonblocking(s);
+            return std::make_shared<Socket>(s);
+        }
+
+        setNonblocking(s);
+        int result = ::connect(s, (sockaddr*)&addr.addr, sizeof(sockaddr_in));
+        int connectionError = 0;
+
+        if (result) {
+#ifdef _WIN32
+            int connectError = WSAGetLastError();
+            bool inProgress = connectError == WSAEWOULDBLOCK || connectError == WSAEINPROGRESS;
+#else
+            int connectError = errno;
+            bool inProgress = connectError == EINPROGRESS || connectError == EWOULDBLOCK;
+#endif
+            if (!inProgress) {
+                closeSocket(s);
+#ifdef _WIN32
+                throw std::runtime_error("Could not connect (error " + std::to_string(connectError) + ")");
+#else
+                throw std::runtime_error(std::string("Could not connect: ") + strerror(connectError));
+#endif
+            }
         }
 
         if (result) {
             fd_set writefds;
             FD_ZERO(&writefds);
             FD_SET(s, &writefds);
-            timeval timeout { 3, 0 };
-            result = select((int)s + 1, nullptr, &writefds, nullptr, &timeout);
+            timeval timeoutValue {
+                timeout / 1000,
+                (timeout % 1000) * 1000
+            };
+            result = select((int)s + 1, nullptr, &writefds, nullptr, &timeoutValue);
 
-            int socketError = 0;
-#ifdef _WIN32
-            int socketErrorLen = sizeof(socketError);
-#else
-            socklen_t socketErrorLen = sizeof(socketError);
-#endif
-            if (result <= 0 || !FD_ISSET(s, &writefds) || getsockopt(s, SOL_SOCKET, SO_ERROR, (char*)&socketError, &socketErrorLen) || socketError) {
+            if (result == 0) {
                 closeSocket(s);
-                throw std::runtime_error("Could not connect within 3 seconds");
+                throw std::runtime_error("Connection timed out");
+            }
+            if (result < 0 || !FD_ISSET(s, &writefds)) {
+#ifdef _WIN32
+                connectionError = WSAGetLastError();
+#else
+                connectionError = errno;
+#endif
+            }
+            else {
+                int socketError = 0;
+#ifdef _WIN32
+                int socketErrorLen = sizeof(socketError);
+#else
+                socklen_t socketErrorLen = sizeof(socketError);
+#endif
+                if (getsockopt(s, SOL_SOCKET, SO_ERROR, (char*)&socketError, &socketErrorLen) == 0) {
+                    connectionError = socketError;
+                }
+                else {
+#ifdef _WIN32
+                    connectionError = WSAGetLastError();
+#else
+                    connectionError = errno;
+#endif
+                }
+            }
+
+            if (connectionError) {
+                closeSocket(s);
+#ifdef _WIN32
+                throw std::runtime_error("Could not connect (error " + std::to_string(connectionError) + ")");
+#else
+                throw std::runtime_error(std::string("Could not connect: ") + strerror(connectionError));
+#endif
             }
         }
 
@@ -471,7 +529,36 @@ namespace net {
     }
 
     std::shared_ptr<Socket> connect(std::string host, int port) {
-        return connect(Address(host, port));
+        return connect(std::move(host), port, NO_TIMEOUT);
+    }
+
+    std::shared_ptr<Socket> connect(std::string host, int port, int timeout) {
+        init();
+
+        if (timeout < 0) {
+            return connect(Address(host, port), timeout);
+        }
+
+        const auto started = std::chrono::steady_clock::now();
+        sockaddr_in resolved{};
+        detail::ResolveStatus resolveStatus = detail::resolveIPv4(host, port, timeout, resolved);
+        if (resolveStatus == detail::ResolveStatus::TIMEOUT) {
+            throw std::runtime_error("Host name resolution timed out");
+        }
+        if (resolveStatus != detail::ResolveStatus::SUCCESS) {
+            throw std::runtime_error("Unknown host");
+        }
+
+        int elapsedMS = (int)std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - started).count();
+        int remainingMS = timeout - elapsedMS;
+        if (remainingMS <= 0) {
+            throw std::runtime_error("Connection timed out");
+        }
+
+        Address address;
+        address.addr = resolved;
+        return connect(address, remainingMS);
     }
 
     std::shared_ptr<Socket> openudp(const Address& raddr, const Address& laddr, bool allowBroadcast) {

--- a/core/src/utils/net.cpp
+++ b/core/src/utils/net.cpp
@@ -53,12 +53,13 @@ namespace net {
 #endif
     }
 
-    void setNonblocking(SockHandle_t sock) {
+    bool setNonblocking(SockHandle_t sock) {
 #ifdef _WIN32
         u_long enabled = 1;
-        ioctlsocket(sock, FIONBIO, &enabled);
+        return ioctlsocket(sock, FIONBIO, &enabled) == 0;
 #else
-        fcntl(sock, F_SETFL, O_NONBLOCK);
+        int flags = fcntl(sock, F_GETFL, 0);
+        return flags >= 0 && fcntl(sock, F_SETFL, flags | O_NONBLOCK) == 0;
 #endif
     }
 
@@ -264,7 +265,10 @@ namespace net {
         }
 
         // Enable nonblocking mode
-        setNonblocking(s);
+        if (!setNonblocking(s)) {
+            closeSocket(s);
+            throw std::runtime_error("Could not configure non-blocking socket");
+        }
 
         return std::make_shared<Socket>(s);
     }
@@ -415,7 +419,10 @@ namespace net {
         }
 
         // Enable nonblocking mode
-        setNonblocking(s);
+        if (!setNonblocking(s)) {
+            closeSocket(s);
+            throw std::runtime_error("Could not configure non-blocking socket");
+        }
 
         // Return listener class
         return std::make_shared<Listener>(s);
@@ -448,11 +455,17 @@ namespace net {
                 throw std::runtime_error(std::string("Could not connect: ") + strerror(connectError));
 #endif
             }
-            setNonblocking(s);
+            if (!setNonblocking(s)) {
+                closeSocket(s);
+                throw std::runtime_error("Could not configure non-blocking socket");
+            }
             return std::make_shared<Socket>(s);
         }
 
-        setNonblocking(s);
+        if (!setNonblocking(s)) {
+            closeSocket(s);
+            throw std::runtime_error("Could not configure non-blocking socket");
+        }
         int result = ::connect(s, (sockaddr*)&addr.addr, sizeof(sockaddr_in));
         int connectionError = 0;
 

--- a/core/src/utils/net.cpp
+++ b/core/src/utils/net.cpp
@@ -431,15 +431,40 @@ namespace net {
         // Create socket
         SockHandle_t s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
-        // Connect to server
-        if (::connect(s, (sockaddr*)&addr.addr, sizeof(sockaddr_in))) {
+        // A blocking connect can take minutes on an unreachable address.  This
+        // function is used from source-module menu handlers, so keep the UI
+        // responsive by making the connection attempt non-blocking and waiting
+        // for a bounded time instead.
+        setNonblocking(s);
+
+        int result = ::connect(s, (sockaddr*)&addr.addr, sizeof(sockaddr_in));
+#ifdef _WIN32
+        if (result && WSAGetLastError() != WSAEWOULDBLOCK && WSAGetLastError() != WSAEINPROGRESS) {
+#else
+        if (result && errno != EINPROGRESS && errno != EWOULDBLOCK) {
+#endif
             closeSocket(s);
             throw std::runtime_error("Could not connect");
-            return NULL;
         }
 
-        // Enable nonblocking mode
-        setNonblocking(s);
+        if (result) {
+            fd_set writefds;
+            FD_ZERO(&writefds);
+            FD_SET(s, &writefds);
+            timeval timeout { 3, 0 };
+            result = select((int)s + 1, nullptr, &writefds, nullptr, &timeout);
+
+            int socketError = 0;
+#ifdef _WIN32
+            int socketErrorLen = sizeof(socketError);
+#else
+            socklen_t socketErrorLen = sizeof(socketError);
+#endif
+            if (result <= 0 || !FD_ISSET(s, &writefds) || getsockopt(s, SOL_SOCKET, SO_ERROR, (char*)&socketError, &socketErrorLen) || socketError) {
+                closeSocket(s);
+                throw std::runtime_error("Could not connect within 3 seconds");
+            }
+        }
 
         // Return socket class
         return std::make_shared<Socket>(s);

--- a/core/src/utils/net.h
+++ b/core/src/utils/net.h
@@ -237,7 +237,9 @@ namespace net {
      * @param addr Remote address.
      * @return Socket instance on success, Throws runtime_error otherwise.
      */
-    std::shared_ptr<Socket> connect(const Address& addr);  
+    std::shared_ptr<Socket> connect(const Address& addr);
+    // Timed variant; timeout is in milliseconds.
+    std::shared_ptr<Socket> connect(const Address& addr, int timeout);
 
     /**
      * Create TCP connection.
@@ -245,7 +247,9 @@ namespace net {
      * @param port Remote port.
      * @return Socket instance on success, Throws runtime_error otherwise.
      */
-    std::shared_ptr<Socket> connect(std::string host, int port);  
+    std::shared_ptr<Socket> connect(std::string host, int port);
+    // Timed variant; timeout bounds name resolution and connection.
+    std::shared_ptr<Socket> connect(std::string host, int port, int timeout);
 
     /**
      * Create UDP socket.

--- a/core/src/utils/net_resolve.h
+++ b/core/src/utils/net_resolve.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace net::detail {
+    enum class ResolveStatus {
+        SUCCESS,
+        ERROR,
+        TIMEOUT
+    };
+
+    struct ResolveResult {
+        std::mutex mtx;
+        std::condition_variable cnd;
+        sockaddr_in address{};
+        bool done = false;
+        bool success = false;
+    };
+
+    inline void resolveIPv4Worker(const std::string& host, uint16_t port, const std::shared_ptr<ResolveResult>& result) {
+        addrinfo hints{};
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_protocol = IPPROTO_TCP;
+
+        addrinfo* addresses = nullptr;
+        int error = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &addresses);
+
+        sockaddr_in address{};
+        bool success = false;
+        if (error == 0 && addresses && addresses->ai_addrlen >= sizeof(sockaddr_in)) {
+            memcpy(&address, addresses->ai_addr, sizeof(address));
+            success = true;
+        }
+        if (addresses) {
+            freeaddrinfo(addresses);
+        }
+
+        {
+            std::lock_guard lck(result->mtx);
+            result->address = address;
+            result->success = success;
+            result->done = true;
+        }
+        result->cnd.notify_all();
+    }
+
+    // getaddrinfo has no portable cancellation API. Run it on an isolated
+    // shared-state worker when a deadline is requested, so a slow resolver
+    // cannot extend the caller's connection deadline or object lifetime.
+    inline ResolveStatus resolveIPv4(const std::string& host, uint16_t port, int timeoutMS, sockaddr_in& address) {
+        auto result = std::make_shared<ResolveResult>();
+
+        if (timeoutMS < 0) {
+            resolveIPv4Worker(host, port, result);
+        }
+        else {
+            std::thread resolver(resolveIPv4Worker, host, port, result);
+            std::unique_lock lck(result->mtx);
+            if (!result->cnd.wait_for(lck, std::chrono::milliseconds(timeoutMS), [&]() { return result->done; })) {
+                lck.unlock();
+                resolver.detach();
+                return ResolveStatus::TIMEOUT;
+            }
+            lck.unlock();
+            resolver.join();
+        }
+
+        std::lock_guard lck(result->mtx);
+        if (!result->success) {
+            return ResolveStatus::ERROR;
+        }
+        address = result->address;
+        return ResolveStatus::SUCCESS;
+    }
+}

--- a/core/src/utils/net_resolve.h
+++ b/core/src/utils/net_resolve.h
@@ -1,13 +1,20 @@
 #pragma once
 
+#include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+
+#ifndef _WIN32
+#include <arpa/inet.h>
+#endif
 
 namespace net::detail {
     enum class ResolveStatus {
@@ -19,19 +26,22 @@ namespace net::detail {
     struct ResolveResult {
         std::mutex mtx;
         std::condition_variable cnd;
+        std::string host;
+        uint16_t port = 0;
         sockaddr_in address{};
+        std::atomic<bool> abandoned{false};
         bool done = false;
         bool success = false;
     };
 
-    inline void resolveIPv4Worker(const std::string& host, uint16_t port, const std::shared_ptr<ResolveResult>& result) {
+    inline void resolveIPv4Worker(const std::shared_ptr<ResolveResult>& result) {
         addrinfo hints{};
         hints.ai_family = AF_INET;
         hints.ai_socktype = SOCK_STREAM;
         hints.ai_protocol = IPPROTO_TCP;
 
         addrinfo* addresses = nullptr;
-        int error = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &addresses);
+        int error = getaddrinfo(result->host.c_str(), std::to_string(result->port).c_str(), &hints, &addresses);
 
         sockaddr_in address{};
         bool success = false;
@@ -52,25 +62,82 @@ namespace net::detail {
         result->cnd.notify_all();
     }
 
-    // getaddrinfo has no portable cancellation API. Run it on an isolated
-    // shared-state worker when a deadline is requested, so a slow resolver
-    // cannot extend the caller's connection deadline or object lifetime.
+    // getaddrinfo has no portable cancellation API. A single process-lifetime
+    // worker bounds the number of potentially stuck resolver threads to one.
+    // Timed-out requests are removed from its queue before they can accumulate.
+    class ResolverService {
+    public:
+        ResolverService() : worker(&ResolverService::run, this) {}
+
+        void submit(const std::shared_ptr<ResolveResult>& result) {
+            {
+                std::lock_guard lck(mtx);
+                queue.push_back(result);
+            }
+            cnd.notify_one();
+        }
+
+        void abandon(const std::shared_ptr<ResolveResult>& result) {
+            result->abandoned = true;
+            std::lock_guard lck(mtx);
+            queue.erase(std::remove(queue.begin(), queue.end(), result), queue.end());
+        }
+
+    private:
+        void run() {
+            while (true) {
+                std::shared_ptr<ResolveResult> result;
+                {
+                    std::unique_lock lck(mtx);
+                    cnd.wait(lck, [this]() { return !queue.empty(); });
+                    result = std::move(queue.front());
+                    queue.pop_front();
+                }
+                if (!result->abandoned) {
+                    resolveIPv4Worker(result);
+                }
+            }
+        }
+
+        std::mutex mtx;
+        std::condition_variable cnd;
+        std::deque<std::shared_ptr<ResolveResult>> queue;
+        std::thread worker;
+    };
+
+    inline ResolverService& resolverService() {
+        // Intentionally process-lifetime: joining a worker blocked in
+        // getaddrinfo during static destruction would hang application exit.
+        static ResolverService* service = new ResolverService();
+        return *service;
+    }
+
     inline ResolveStatus resolveIPv4(const std::string& host, uint16_t port, int timeoutMS, sockaddr_in& address) {
+        sockaddr_in numericAddress{};
+        numericAddress.sin_family = AF_INET;
+        numericAddress.sin_port = htons(port);
+        if (inet_pton(AF_INET, host.c_str(), &numericAddress.sin_addr) == 1) {
+            address = numericAddress;
+            return ResolveStatus::SUCCESS;
+        }
+
         auto result = std::make_shared<ResolveResult>();
+        result->host = host;
+        result->port = port;
 
         if (timeoutMS < 0) {
-            resolveIPv4Worker(host, port, result);
+            resolveIPv4Worker(result);
         }
         else {
-            std::thread resolver(resolveIPv4Worker, host, port, result);
+            ResolverService& service = resolverService();
+            service.submit(result);
             std::unique_lock lck(result->mtx);
             if (!result->cnd.wait_for(lck, std::chrono::milliseconds(timeoutMS), [&]() { return result->done; })) {
                 lck.unlock();
-                resolver.detach();
+                service.abandon(result);
                 return ResolveStatus::TIMEOUT;
             }
             lck.unlock();
-            resolver.join();
         }
 
         std::lock_guard lck(result->mtx);

--- a/core/src/utils/networking.cpp
+++ b/core/src/utils/networking.cpp
@@ -352,16 +352,7 @@ namespace net {
     }
 
     Conn connect(std::string host, uint16_t port, int timeoutMS) {
-        Socket sock;
-
         initNetworking();
-
-        // Create a socket
-        sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-        if (sock < 0) {
-            throw std::runtime_error("Could not create socket");
-            return NULL;
-        }
 
         const auto started = std::chrono::steady_clock::now();
 
@@ -369,15 +360,21 @@ namespace net {
         sockaddr_in addr{};
         detail::ResolveStatus resolveStatus = detail::resolveIPv4(host, port, timeoutMS, addr);
         if (resolveStatus != detail::ResolveStatus::SUCCESS) {
-#ifdef _WIN32
-            closesocket(sock);
-#else
-            ::close(sock);
-#endif
             if (resolveStatus == detail::ResolveStatus::TIMEOUT) {
                 throw std::runtime_error("Host name resolution timed out");
             }
             throw std::runtime_error("Could not resolve host");
+        }
+
+        // Create a socket only after resolution, so a resolver setup failure
+        // cannot leak the handle.
+        Socket sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+#ifdef _WIN32
+        if (sock == INVALID_SOCKET) {
+#else
+        if (sock < 0) {
+#endif
+            throw std::runtime_error("Could not create socket");
         }
 
         if (timeoutMS < 0) {

--- a/core/src/utils/networking.cpp
+++ b/core/src/utils/networking.cpp
@@ -1,7 +1,9 @@
 #include <utils/networking.h>
 #include <assert.h>
 #include <utils/flog.h>
+#include <utils/net_resolve.h>
 #include <stdexcept>
+#include <chrono>
 
 #ifndef _WIN32
 #include <cerrno>
@@ -9,10 +11,22 @@
 #endif
 
 namespace net {
+    namespace {
+        std::once_flag networkInitFlag;
 
+        void initNetworking() {
+            std::call_once(networkInitFlag, []() {
 #ifdef _WIN32
-    extern bool winsock_init = false;
+                WSADATA wsa;
+                if (WSAStartup(MAKEWORD(2, 2), &wsa)) {
+                    throw std::runtime_error("Could not initialize WinSock2");
+                }
+#else
+                signal(SIGPIPE, SIG_IGN);
 #endif
+            });
+        }
+    }
 
     ConnClass::ConnClass(Socket sock, struct sockaddr_in raddr, bool udp) {
         _sock = sock;
@@ -333,23 +347,14 @@ namespace net {
     }
 
 
+    Conn connect(std::string host, uint16_t port) {
+        return connect(std::move(host), port, -1);
+    }
+
     Conn connect(std::string host, uint16_t port, int timeoutMS) {
         Socket sock;
 
-#ifdef _WIN32
-        // Initialize WinSock2
-        if (!winsock_init) {
-            WSADATA wsa;
-            if (WSAStartup(MAKEWORD(2, 2), &wsa)) {
-                throw std::runtime_error("Could not initialize WinSock2");
-                return NULL;
-            }
-            winsock_init = true;
-        }
-        assert(winsock_init);
-#else
-        signal(SIGPIPE, SIG_IGN);
-#endif
+        initNetworking();
 
         // Create a socket
         sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
@@ -358,23 +363,37 @@ namespace net {
             return NULL;
         }
 
-        // Get address from hostname/ip
-        hostent* remoteHost = gethostbyname(host.c_str());
-        if (remoteHost == NULL || remoteHost->h_addr_list[0] == NULL) {
+        const auto started = std::chrono::steady_clock::now();
+
+        // Resolve the address within the same overall deadline as connect().
+        sockaddr_in addr{};
+        detail::ResolveStatus resolveStatus = detail::resolveIPv4(host, port, timeoutMS, addr);
+        if (resolveStatus != detail::ResolveStatus::SUCCESS) {
 #ifdef _WIN32
             closesocket(sock);
 #else
             ::close(sock);
 #endif
-            throw std::runtime_error("Could get address from host");
+            if (resolveStatus == detail::ResolveStatus::TIMEOUT) {
+                throw std::runtime_error("Host name resolution timed out");
+            }
+            throw std::runtime_error("Could not resolve host");
         }
-        uint32_t* naddr = (uint32_t*)remoteHost->h_addr_list[0];
 
-        // Create host address
-        struct sockaddr_in addr;
-        addr.sin_addr.s_addr = *naddr;
-        addr.sin_family = AF_INET;
-        addr.sin_port = htons(port);
+        if (timeoutMS < 0) {
+            if (::connect(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+#ifdef _WIN32
+                int connectError = WSAGetLastError();
+                closesocket(sock);
+                throw std::runtime_error("Could not connect to host (error " + std::to_string(connectError) + ")");
+#else
+                int connectError = errno;
+                ::close(sock);
+                throw std::runtime_error(std::string("Could not connect to host: ") + strerror(connectError));
+#endif
+            }
+            return Conn(new ConnClass(sock));
+        }
 
         // Make the handshake non-blocking, so an unreachable server cannot
         // hold the GUI thread until the OS-level TCP retry timeout expires.
@@ -392,13 +411,27 @@ namespace net {
         }
 #endif
 
+        int elapsedMS = (int)std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - started).count();
+        int remainingMS = timeoutMS - elapsedMS;
+        if (remainingMS <= 0) {
+#ifdef _WIN32
+            closesocket(sock);
+#else
+            ::close(sock);
+#endif
+            throw std::runtime_error("Connection timed out");
+        }
+
         int connectResult = ::connect(sock, (struct sockaddr*)&addr, sizeof(addr));
         bool connected = (connectResult == 0);
+        int connectionError = 0;
         if (!connected) {
 #ifdef _WIN32
             int connectError = WSAGetLastError();
             bool inProgress = (connectError == WSAEINPROGRESS || connectError == WSAEWOULDBLOCK);
 #else
+            int connectError = errno;
             bool inProgress = (errno == EINPROGRESS || errno == EWOULDBLOCK);
 #endif
             if (inProgress) {
@@ -406,8 +439,8 @@ namespace net {
                 FD_ZERO(&writeSet);
                 FD_SET(sock, &writeSet);
                 timeval timeout {
-                    timeoutMS / 1000,
-                    (timeoutMS % 1000) * 1000
+                    remainingMS / 1000,
+                    (remainingMS % 1000) * 1000
                 };
 
 #ifdef _WIN32
@@ -415,15 +448,43 @@ namespace net {
 #else
                 int selected = select(sock + 1, NULL, &writeSet, NULL, &timeout);
 #endif
-                if (selected > 0 && FD_ISSET(sock, &writeSet)) {
+                if (selected == 0) {
+#ifdef _WIN32
+                    closesocket(sock);
+#else
+                    ::close(sock);
+#endif
+                    throw std::runtime_error("Connection timed out");
+                }
+                if (selected < 0 || !FD_ISSET(sock, &writeSet)) {
+#ifdef _WIN32
+                    connectionError = WSAGetLastError();
+#else
+                    connectionError = errno;
+#endif
+                }
+                else {
                     int socketError = 0;
 #ifdef _WIN32
                     int socketErrorLen = sizeof(socketError);
 #else
                     socklen_t socketErrorLen = sizeof(socketError);
 #endif
-                    connected = getsockopt(sock, SOL_SOCKET, SO_ERROR, (char*)&socketError, &socketErrorLen) == 0 && socketError == 0;
+                    if (getsockopt(sock, SOL_SOCKET, SO_ERROR, (char*)&socketError, &socketErrorLen) == 0) {
+                        connected = socketError == 0;
+                        connectionError = socketError;
+                    }
+                    else {
+#ifdef _WIN32
+                        connectionError = WSAGetLastError();
+#else
+                        connectionError = errno;
+#endif
+                    }
                 }
+            }
+            else {
+                connectionError = connectError;
             }
         }
 
@@ -433,15 +494,25 @@ namespace net {
 #else
             ::close(sock);
 #endif
-            throw std::runtime_error("Could not connect to host within timeout");
+#ifdef _WIN32
+            throw std::runtime_error("Could not connect to host (error " + std::to_string(connectionError) + ")");
+#else
+            throw std::runtime_error(std::string("Could not connect to host: ") + strerror(connectionError));
+#endif
         }
 
         // ConnClass expects a regular blocking stream socket for its workers.
 #ifdef _WIN32
         nonBlocking = 0;
-        ioctlsocket(sock, FIONBIO, &nonBlocking);
+        if (ioctlsocket(sock, FIONBIO, &nonBlocking) != 0) {
+            closesocket(sock);
+            throw std::runtime_error("Could not restore blocking socket mode");
+        }
 #else
-        fcntl(sock, F_SETFL, oldFlags);
+        if (fcntl(sock, F_SETFL, oldFlags) < 0) {
+            ::close(sock);
+            throw std::runtime_error("Could not restore blocking socket mode");
+        }
 #endif
 
         return Conn(new ConnClass(sock));
@@ -450,20 +521,7 @@ namespace net {
     Listener listen(std::string host, uint16_t port) {
         Socket listenSock;
 
-#ifdef _WIN32
-        // Initialize WinSock2
-        if (!winsock_init) {
-            WSADATA wsa;
-            if (WSAStartup(MAKEWORD(2, 2), &wsa)) {
-                throw std::runtime_error("Could not initialize WinSock2");
-                return NULL;
-            }
-            winsock_init = true;
-        }
-        assert(winsock_init);
-#else
-        signal(SIGPIPE, SIG_IGN);
-#endif
+        initNetworking();
 
         // Create a socket
         listenSock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
@@ -516,20 +574,7 @@ namespace net {
     Conn openUDP(std::string host, uint16_t port, std::string remoteHost, uint16_t remotePort, bool bindSocket) {
         Socket sock;
 
-#ifdef _WIN32
-        // Initialize WinSock2
-        if (!winsock_init) {
-            WSADATA wsa;
-            if (WSAStartup(MAKEWORD(2, 2), &wsa)) {
-                throw std::runtime_error("Could not initialize WinSock2");
-                return NULL;
-            }
-            winsock_init = true;
-        }
-        assert(winsock_init);
-#else
-        signal(SIGPIPE, SIG_IGN);
-#endif
+        initNetworking();
 
         // Create a socket
         sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);

--- a/core/src/utils/networking.cpp
+++ b/core/src/utils/networking.cpp
@@ -3,6 +3,11 @@
 #include <utils/flog.h>
 #include <stdexcept>
 
+#ifndef _WIN32
+#include <cerrno>
+#include <fcntl.h>
+#endif
+
 namespace net {
 
 #ifdef _WIN32
@@ -328,7 +333,7 @@ namespace net {
     }
 
 
-    Conn connect(std::string host, uint16_t port) {
+    Conn connect(std::string host, uint16_t port, int timeoutMS) {
         Socket sock;
 
 #ifdef _WIN32
@@ -356,8 +361,12 @@ namespace net {
         // Get address from hostname/ip
         hostent* remoteHost = gethostbyname(host.c_str());
         if (remoteHost == NULL || remoteHost->h_addr_list[0] == NULL) {
+#ifdef _WIN32
+            closesocket(sock);
+#else
+            ::close(sock);
+#endif
             throw std::runtime_error("Could get address from host");
-            return NULL;
         }
         uint32_t* naddr = (uint32_t*)remoteHost->h_addr_list[0];
 
@@ -367,11 +376,73 @@ namespace net {
         addr.sin_family = AF_INET;
         addr.sin_port = htons(port);
 
-        // Connect to host
-        if (::connect(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
-            throw std::runtime_error("Could not connect to host");
-            return NULL;
+        // Make the handshake non-blocking, so an unreachable server cannot
+        // hold the GUI thread until the OS-level TCP retry timeout expires.
+#ifdef _WIN32
+        u_long nonBlocking = 1;
+        if (ioctlsocket(sock, FIONBIO, &nonBlocking) != 0) {
+            closesocket(sock);
+            throw std::runtime_error("Could not configure non-blocking socket");
         }
+#else
+        int oldFlags = fcntl(sock, F_GETFL, 0);
+        if (oldFlags < 0 || fcntl(sock, F_SETFL, oldFlags | O_NONBLOCK) < 0) {
+            ::close(sock);
+            throw std::runtime_error("Could not configure non-blocking socket");
+        }
+#endif
+
+        int connectResult = ::connect(sock, (struct sockaddr*)&addr, sizeof(addr));
+        bool connected = (connectResult == 0);
+        if (!connected) {
+#ifdef _WIN32
+            int connectError = WSAGetLastError();
+            bool inProgress = (connectError == WSAEINPROGRESS || connectError == WSAEWOULDBLOCK);
+#else
+            bool inProgress = (errno == EINPROGRESS || errno == EWOULDBLOCK);
+#endif
+            if (inProgress) {
+                fd_set writeSet;
+                FD_ZERO(&writeSet);
+                FD_SET(sock, &writeSet);
+                timeval timeout {
+                    timeoutMS / 1000,
+                    (timeoutMS % 1000) * 1000
+                };
+
+#ifdef _WIN32
+                int selected = select(0, NULL, &writeSet, NULL, &timeout);
+#else
+                int selected = select(sock + 1, NULL, &writeSet, NULL, &timeout);
+#endif
+                if (selected > 0 && FD_ISSET(sock, &writeSet)) {
+                    int socketError = 0;
+#ifdef _WIN32
+                    int socketErrorLen = sizeof(socketError);
+#else
+                    socklen_t socketErrorLen = sizeof(socketError);
+#endif
+                    connected = getsockopt(sock, SOL_SOCKET, SO_ERROR, (char*)&socketError, &socketErrorLen) == 0 && socketError == 0;
+                }
+            }
+        }
+
+        if (!connected) {
+#ifdef _WIN32
+            closesocket(sock);
+#else
+            ::close(sock);
+#endif
+            throw std::runtime_error("Could not connect to host within timeout");
+        }
+
+        // ConnClass expects a regular blocking stream socket for its workers.
+#ifdef _WIN32
+        nonBlocking = 0;
+        ioctlsocket(sock, FIONBIO, &nonBlocking);
+#else
+        fcntl(sock, F_SETFL, oldFlags);
+#endif
 
         return Conn(new ConnClass(sock));
     }

--- a/core/src/utils/networking.h
+++ b/core/src/utils/networking.h
@@ -123,7 +123,9 @@ namespace net {
 
     typedef std::unique_ptr<ListenerClass> Listener;
 
-    Conn connect(std::string host, uint16_t port);
+    // A bounded timeout prevents a stalled TCP handshake from freezing a GUI
+    // caller while the operating system retries an unreachable host.
+    Conn connect(std::string host, uint16_t port, int timeoutMS = 3000);
     Listener listen(std::string host, uint16_t port);
     Conn openUDP(std::string host, uint16_t port, std::string remoteHost, uint16_t remotePort, bool bindSocket = true);
 

--- a/core/src/utils/networking.h
+++ b/core/src/utils/networking.h
@@ -123,13 +123,10 @@ namespace net {
 
     typedef std::unique_ptr<ListenerClass> Listener;
 
-    // A bounded timeout prevents a stalled TCP handshake from freezing a GUI
-    // caller while the operating system retries an unreachable host.
-    Conn connect(std::string host, uint16_t port, int timeoutMS = 3000);
+    Conn connect(std::string host, uint16_t port);
+    // timeoutMS bounds name resolution and the TCP handshake.
+    Conn connect(std::string host, uint16_t port, int timeoutMS);
     Listener listen(std::string host, uint16_t port);
     Conn openUDP(std::string host, uint16_t port, std::string remoteHost, uint16_t remotePort, bool bindSocket = true);
 
-#ifdef _WIN32
-    extern bool winsock_init;
-#endif
 }

--- a/source_modules/sdrpp_server_source/src/main.cpp
+++ b/source_modules/sdrpp_server_source/src/main.cpp
@@ -361,8 +361,8 @@ private:
             connectionThread = std::thread([this, host, targetPort, authKey, useAuth]() {
                 try {
                     auto newClient = useAuth
-                        ? server::connect(host, targetPort, &stream, *authKey, 3000)
-                        : server::connect(host, targetPort, &stream, std::string(), 3000);
+                        ? server::connect(host, targetPort, &stream, *authKey, 3000, &connectionCancelled)
+                        : server::connect(host, targetPort, &stream, std::string(), 3000, &connectionCancelled);
 
                     bool discard = false;
                     {

--- a/source_modules/sdrpp_server_source/src/main.cpp
+++ b/source_modules/sdrpp_server_source/src/main.cpp
@@ -12,8 +12,11 @@
 #include <gui/dialogs/dialog_box.h>
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
+#include <thread>
 
 #define CONCAT(a, b) ((std::string(a) + b).c_str())
 
@@ -81,6 +84,9 @@ public:
         // If still selected, unregisterSource fires menuDeselected, which
         // unbinds frameDrawHandler.
         stop(this);
+        if (connectionThread.joinable()) {
+            connectionThread.join();
+        }
         sigpath::sourceManager.unregisterSource("SDR++ Server");
     }
 
@@ -187,9 +193,12 @@ private:
     static void menuHandler(void* ctx) {
         SDRPPServerSourceModule* _this = (SDRPPServerSourceModule*)ctx;
 
+        _this->pollConnection();
+
         float menuWidth = ImGui::GetContentRegionAvail().x;
 
         bool connected = _this->connected();
+        const bool connecting = _this->connecting.load();
         gui::mainWindow.playButtonLocked = !connected;
 
         ImGui::GenericDialog("##sdrpp_srv_src_err_dialog", _this->serverBusy, GENERIC_DIALOG_BUTTONS_OK, [=](){
@@ -199,7 +208,7 @@ private:
             ImGui::TextUnformatted("Authentication failed.");
         });
 
-        if (connected) { style::beginDisabled(); }
+        if (connected || connecting) { style::beginDisabled(); }
         if (ImGui::InputText(CONCAT("##sdrpp_srv_srv_host_", _this->name), _this->hostname, 1023)) {
             config.acquire();
             config.conf["hostname"] = _this->hostname;
@@ -224,15 +233,17 @@ private:
                 _this->clearPasswordForServer();
             }
         }
-        if (connected) { style::endDisabled(); }
+        if (connected || connecting) { style::endDisabled(); }
 
         if (_this->running) { style::beginDisabled(); }
+        if (connecting) { style::beginDisabled(); }
         if (!connected && ImGui::Button("Connect##sdrpp_srv_source", ImVec2(menuWidth, 0))) {
             _this->tryConnect();
         }
         else if (connected && ImGui::Button("Disconnect##sdrpp_srv_source", ImVec2(menuWidth, 0))) {
             _this->client->close();
         }
+        if (connecting) { style::endDisabled(); }
         if (_this->running) { style::endDisabled(); }
 
 
@@ -297,7 +308,10 @@ private:
         else {
             ImGui::TextUnformatted("Status:");
             ImGui::SameLine();
-            ImGui::TextUnformatted("Not connected (--.--- Mbit/s)");
+            ImGui::TextUnformatted(connecting ? "Connecting..." : "Not connected (--.--- Mbit/s)");
+            if (!connecting && !_this->lastConnectionError.empty()) {
+                ImGui::TextColored(ImVec4(1.0f, 0.35f, 0.35f, 1.0f), "Connection failed: %s", _this->lastConnectionError.c_str());
+            }
         }
     }
 
@@ -306,28 +320,76 @@ private:
     }
 
     void tryConnect() {
+        if (connecting.exchange(true)) { return; }
+
+        if (connectionThread.joinable()) {
+            connectionThread.join();
+        }
+        serverBusy = false;
+        authFailed = false;
+        lastConnectionError.clear();
+        {
+            std::lock_guard lck(connectionMtx);
+            connectionError.clear();
+        }
+
+        const std::string host = hostname;
+        const int targetPort = port;
+        server::AuthKey authKey{};
+        const bool useAuth = savedAuthKeyValid || password[0] != 0;
+        if (savedAuthKeyValid) {
+            authKey = savedAuthKey;
+        }
+        else if (useAuth) {
+            server::deriveAuthKey(std::string(password), authKey);
+        }
+
+        connectionThread = std::thread([this, host, targetPort, authKey, useAuth]() {
+            try {
+                auto newClient = useAuth
+                    ? server::connect(host, targetPort, &stream, authKey)
+                    : server::connect(host, targetPort, &stream);
+                std::lock_guard lck(connectionMtx);
+                pendingClient = std::move(newClient);
+            }
+            catch (const std::exception& e) {
+                std::lock_guard lck(connectionMtx);
+                connectionError = e.what();
+            }
+            connecting = false;
+        });
+    }
+
+    void pollConnection() {
+        if (connecting || !connectionThread.joinable()) { return; }
+
+        connectionThread.join();
+
+        std::shared_ptr<server::Client> newClient;
+        std::string error;
+        {
+            std::lock_guard lck(connectionMtx);
+            newClient = std::move(pendingClient);
+            error = std::move(connectionError);
+        }
+        if (!newClient) {
+            if (!error.empty()) {
+                flog::error("Could not connect to SDR: {}", error);
+                lastConnectionError = error;
+                if (error == "Server busy") { serverBusy = true; }
+                if (error == "Authentication failed") { authFailed = true; }
+            }
+            return;
+        }
+
         try {
-            serverBusy = false;
-            authFailed = false;
-            if (client) { client.reset(); }
-            if (savedAuthKeyValid) {
-                client = server::connect(hostname, port, &stream, savedAuthKey);
-            }
-            else if (password[0] != 0) {
-                server::AuthKey authKey{};
-                server::deriveAuthKey(std::string(password), authKey);
-                client = server::connect(hostname, port, &stream, authKey);
-                std::fill(authKey.begin(), authKey.end(), 0);
-            }
-            else {
-                client = server::connect(hostname, port, &stream);
-            }
+            client = std::move(newClient);
             deviceInit();
         }
         catch (const std::exception& e) {
-            flog::error("Could not connect to SDR: {}", e.what());
-            if (!strcmp(e.what(), "Server busy")) { serverBusy = true; }
-            if (!strcmp(e.what(), "Authentication failed")) { authFailed = true; }
+            flog::error("Could not initialize SDR connection: {}", e.what());
+            lastConnectionError = e.what();
+            client.reset();
         }
     }
 
@@ -511,6 +573,12 @@ private:
     bool compression = false;
 
     std::shared_ptr<server::Client> client;
+    std::shared_ptr<server::Client> pendingClient;
+    std::thread connectionThread;
+    std::mutex connectionMtx;
+    std::string connectionError;
+    std::string lastConnectionError;
+    std::atomic<bool> connecting{false};
 };
 
 MOD_EXPORT void _INIT_() {

--- a/source_modules/sdrpp_server_source/src/main.cpp
+++ b/source_modules/sdrpp_server_source/src/main.cpp
@@ -84,6 +84,7 @@ public:
         // If still selected, unregisterSource fires menuDeselected, which
         // unbinds frameDrawHandler.
         stop(this);
+        cancelConnection();
         if (connectionThread.joinable()) {
             connectionThread.join();
         }
@@ -137,6 +138,7 @@ private:
 
     static void menuDeselected(void* ctx) {
         SDRPPServerSourceModule* _this = (SDRPPServerSourceModule*)ctx;
+        _this->cancelConnection();
         gui::mainWindow.onFrameDraw.unbindHandler(&_this->frameDrawHandler);
         gui::mainWindow.playButtonLocked = false;
         // Release the remote limits so they don't leak into the next source.
@@ -322,8 +324,19 @@ private:
     void tryConnect() {
         if (connecting.exchange(true)) { return; }
 
+        if (port <= 0 || port > 65535) {
+            lastConnectionError = "Port must be between 1 and 65535";
+            connecting = false;
+            return;
+        }
+
         if (connectionThread.joinable()) {
             connectionThread.join();
+        }
+        connectionCancelled = false;
+        if (client) {
+            client->close();
+            client.reset();
         }
         serverBusy = false;
         authFailed = false;
@@ -335,29 +348,65 @@ private:
 
         const std::string host = hostname;
         const int targetPort = port;
-        server::AuthKey authKey{};
+        auto authKey = std::make_shared<server::AuthKey>();
         const bool useAuth = savedAuthKeyValid || password[0] != 0;
         if (savedAuthKeyValid) {
-            authKey = savedAuthKey;
+            *authKey = savedAuthKey;
         }
         else if (useAuth) {
-            server::deriveAuthKey(std::string(password), authKey);
+            server::deriveAuthKey(std::string(password), *authKey);
         }
 
-        connectionThread = std::thread([this, host, targetPort, authKey, useAuth]() {
-            try {
-                auto newClient = useAuth
-                    ? server::connect(host, targetPort, &stream, authKey)
-                    : server::connect(host, targetPort, &stream);
-                std::lock_guard lck(connectionMtx);
-                pendingClient = std::move(newClient);
-            }
-            catch (const std::exception& e) {
-                std::lock_guard lck(connectionMtx);
-                connectionError = e.what();
-            }
+        try {
+            connectionThread = std::thread([this, host, targetPort, authKey, useAuth]() {
+                try {
+                    auto newClient = useAuth
+                        ? server::connect(host, targetPort, &stream, *authKey, 3000)
+                        : server::connect(host, targetPort, &stream, std::string(), 3000);
+
+                    bool discard = false;
+                    {
+                        std::lock_guard lck(connectionMtx);
+                        discard = connectionCancelled.load();
+                        if (!discard) {
+                            pendingClient = std::move(newClient);
+                        }
+                    }
+                    if (discard) {
+                        newClient->close();
+                    }
+                }
+                catch (const std::exception& e) {
+                    if (!connectionCancelled) {
+                        std::lock_guard lck(connectionMtx);
+                        connectionError = e.what();
+                    }
+                }
+                std::fill(authKey->begin(), authKey->end(), 0);
+                connecting = false;
+            });
+        }
+        catch (const std::exception& e) {
+            std::fill(authKey->begin(), authKey->end(), 0);
             connecting = false;
-        });
+            lastConnectionError = std::string("Could not start connection worker: ") + e.what();
+            flog::error("{}", lastConnectionError);
+        }
+    }
+
+    void cancelConnection() {
+        connectionCancelled = true;
+
+        std::shared_ptr<server::Client> abandonedClient;
+        {
+            std::lock_guard lck(connectionMtx);
+            abandonedClient = std::move(pendingClient);
+            connectionError.clear();
+        }
+        if (abandonedClient) {
+            abandonedClient->close();
+        }
+        lastConnectionError.clear();
     }
 
     void pollConnection() {
@@ -365,12 +414,19 @@ private:
 
         connectionThread.join();
 
+        const bool cancelled = connectionCancelled.exchange(false);
         std::shared_ptr<server::Client> newClient;
         std::string error;
         {
             std::lock_guard lck(connectionMtx);
             newClient = std::move(pendingClient);
             error = std::move(connectionError);
+        }
+        if (cancelled) {
+            if (newClient) {
+                newClient->close();
+            }
+            return;
         }
         if (!newClient) {
             if (!error.empty()) {
@@ -398,18 +454,26 @@ private:
         devConfName = serverConfigName();
 
         // Load settings
-        sampleTypeId = sampleTypeList.valueId(dsp::compression::PCM_TYPE_I16);
-        if (config.conf["servers"][devConfName].contains("sampleType")) {
-            std::string key = config.conf["servers"][devConfName]["sampleType"];
-            if (sampleTypeList.keyExists(key)) { sampleTypeId = sampleTypeList.keyId(key); }
+        config.acquire();
+        try {
+            sampleTypeId = sampleTypeList.valueId(dsp::compression::PCM_TYPE_I16);
+            if (config.conf["servers"][devConfName].contains("sampleType")) {
+                std::string key = config.conf["servers"][devConfName]["sampleType"];
+                if (sampleTypeList.keyExists(key)) { sampleTypeId = sampleTypeList.keyId(key); }
+            }
+            if (config.conf["servers"][devConfName].contains("compression")) {
+                compression = config.conf["servers"][devConfName]["compression"];
+            }
+            rxPrebufferId = prebufferList.valueId(100);
+            if (config.conf["servers"][devConfName].contains("rxPrebuffer")) {
+                int prebufferMsec = config.conf["servers"][devConfName]["rxPrebuffer"];
+                if (prebufferList.valueExists(prebufferMsec)) { rxPrebufferId = prebufferList.valueId(prebufferMsec); }
+            }
+            config.release();
         }
-        if (config.conf["servers"][devConfName].contains("compression")) {
-            compression = config.conf["servers"][devConfName]["compression"];
-        }
-        rxPrebufferId = prebufferList.valueId(100);
-        if (config.conf["servers"][devConfName].contains("rxPrebuffer")) {
-            int prebufferMsec = config.conf["servers"][devConfName]["rxPrebuffer"];
-            if (prebufferList.valueExists(prebufferMsec)) { rxPrebufferId = prebufferList.valueId(prebufferMsec); }
+        catch (...) {
+            config.release();
+            throw;
         }
 
         // Set settings
@@ -579,6 +643,7 @@ private:
     std::string connectionError;
     std::string lastConnectionError;
     std::atomic<bool> connecting{false};
+    std::atomic<bool> connectionCancelled{false};
 };
 
 MOD_EXPORT void _INIT_() {

--- a/source_modules/sdrpp_server_source/src/sdrpp_server_client.cpp
+++ b/source_modules/sdrpp_server_source/src/sdrpp_server_client.cpp
@@ -16,7 +16,10 @@ namespace {
 }
 
 namespace server {
-    Client::Client(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const std::string& password) {
+    Client::Client(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const std::string& password)
+        : Client(std::move(sock), out, password, nullptr) {}
+
+    Client::Client(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const std::string& password, const std::atomic<bool>* cancellation) {
         AuthKey authKey{};
         AuthKey* authKeyPtr = nullptr;
         if (!password.empty()) {
@@ -25,7 +28,7 @@ namespace server {
         }
 
         try {
-            init(sock, out, authKeyPtr);
+            init(sock, out, authKeyPtr, cancellation);
         }
         catch (...) {
             std::fill(authKey.begin(), authKey.end(), 0);
@@ -35,7 +38,11 @@ namespace server {
     }
 
     Client::Client(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey) {
-        init(sock, out, &authKey);
+        init(sock, out, &authKey, nullptr);
+    }
+
+    Client::Client(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey, const std::atomic<bool>* cancellation) {
+        init(sock, out, &authKey, cancellation);
     }
 
     void deriveAuthKey(const std::string& password, AuthKey& authKey) {
@@ -44,9 +51,12 @@ namespace server {
             SERVER_AUTH_PBKDF2_ITERATIONS, authKey.data(), authKey.size());
     }
 
-    void Client::init(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const AuthKey* authKey) {
+    void Client::init(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const AuthKey* authKey, const std::atomic<bool>* cancellation) {
         this->sock = sock;
         output = out;
+        if (cancellation && cancellation->load()) {
+            throw std::runtime_error("Connection cancelled");
+        }
 
         // Allocate buffers
         rbuffer = std::make_unique<uint8_t[]>(SERVER_MAX_PACKET_SIZE);
@@ -81,8 +91,8 @@ namespace server {
         // Start worker thread
         workerThread = std::thread(&Client::worker, this);
 
-        int res = hello(authKey);
-        if (res == 0) { res = getUI(); }
+        int res = hello(authKey, cancellation);
+        if (res == 0) { res = getUI(cancellation); }
         if (res < 0) {
             // Close client
             close();
@@ -97,6 +107,8 @@ namespace server {
                 throw std::runtime_error("Incompatible SDR++ server protocol/fork");
             case CONN_ERR_AUTH:
                 throw std::runtime_error("Authentication failed");
+            case CONN_ERR_CANCELLED:
+                throw std::runtime_error("Connection cancelled");
             default:
                 throw std::runtime_error("Unknown error");
             }
@@ -424,7 +436,8 @@ namespace server {
         authCnd.notify_all();
     }
 
-    int Client::hello(const AuthKey* authKey) {
+    int Client::hello(const AuthKey* authKey, const std::atomic<bool>* cancellation) {
+        if (cancellation && cancellation->load()) { return CONN_ERR_CANCELLED; }
         if (!isOpen()) { return CONN_ERR_TIMEOUT; }
 
         auto waiter = awaitCommandAck(COMMAND_HELLO);
@@ -435,8 +448,9 @@ namespace server {
             sendCommandLocked(COMMAND_HELLO, sizeof(hello));
         }
 
-        if (!waiter->await(PROTOCOL_TIMEOUT_MS)) {
+        if (!waiter->await(PROTOCOL_TIMEOUT_MS, cancellation)) {
             forgetCommandAck(waiter);
+            if (cancellation && cancellation->load()) { return CONN_ERR_CANCELLED; }
             if (serverBusy) { return CONN_ERR_BUSY; }
             return CONN_ERR_PROTOCOL;
         }
@@ -450,7 +464,7 @@ namespace server {
 
         if ((hello.capabilities & SERVER_PROTOCOL_CAP_AUTH) != 0) {
             if (!authKey) { return CONN_ERR_AUTH; }
-            int res = authenticate(*authKey);
+            int res = authenticate(*authKey, cancellation);
             if (res < 0) { return res; }
         }
 
@@ -458,14 +472,16 @@ namespace server {
         return 0;
     }
 
-    int Client::authenticate(const AuthKey& authKey) {
+    int Client::authenticate(const AuthKey& authKey, const std::atomic<bool>* cancellation) {
         std::array<uint8_t, SERVER_AUTH_CHALLENGE_SIZE> challenge{};
         {
             std::unique_lock lck(authMtx);
-            if (!authCnd.wait_for(lck, std::chrono::milliseconds(PROTOCOL_TIMEOUT_MS), [this]() {
-                return authChallengeReady || authFailed.load() || !isOpen();
-            })) {
-                return CONN_ERR_TIMEOUT;
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(PROTOCOL_TIMEOUT_MS);
+            while (!authChallengeReady && !authFailed.load() && isOpen()) {
+                if (cancellation && cancellation->load()) { return CONN_ERR_CANCELLED; }
+                const auto now = std::chrono::steady_clock::now();
+                if (now >= deadline) { return CONN_ERR_TIMEOUT; }
+                authCnd.wait_until(lck, std::min(deadline, now + std::chrono::milliseconds(50)));
             }
             if (authFailed.load() || !authChallengeReady || !isOpen()) { return CONN_ERR_AUTH; }
             challenge = authChallenge;
@@ -485,8 +501,9 @@ namespace server {
 
         std::fill(response.begin(), response.end(), 0);
 
-        if (!waiter->await(PROTOCOL_TIMEOUT_MS)) {
+        if (!waiter->await(PROTOCOL_TIMEOUT_MS, cancellation)) {
             forgetCommandAck(waiter);
+            if (cancellation && cancellation->load()) { return CONN_ERR_CANCELLED; }
             // The server answers a valid response with COMMAND_DISCONNECT if
             // another client claimed the slot during the handshake.
             if (serverBusy.load()) { return CONN_ERR_BUSY; }
@@ -496,14 +513,16 @@ namespace server {
         return 0;
     }
 
-    int Client::getUI() {
+    int Client::getUI(const std::atomic<bool>* cancellation) {
+        if (cancellation && cancellation->load()) { return CONN_ERR_CANCELLED; }
         if (!isOpen()) { return -1; }
         auto waiter = awaitCommandAck(COMMAND_GET_UI);
         sendCommand(COMMAND_GET_UI, 0);
-        if (!waiter->await(PROTOCOL_TIMEOUT_MS)) {
+        if (!waiter->await(PROTOCOL_TIMEOUT_MS, cancellation)) {
             // Drop the abandoned waiter, otherwise a late ACK for this request
             // would be delivered to a later same-command waiter.
             forgetCommandAck(waiter);
+            if (cancellation && cancellation->load()) { return CONN_ERR_CANCELLED; }
             if (!serverBusy) { flog::error("Timeout out after asking for UI"); };
             return serverBusy ? CONN_ERR_BUSY : CONN_ERR_TIMEOUT;
         }
@@ -570,7 +589,11 @@ namespace server {
     }
 
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const std::string& password, int timeoutMS) {
-        return std::make_shared<Client>(net::connect(host, port, timeoutMS), out, password);
+        return connect(std::move(host), port, out, password, timeoutMS, nullptr);
+    }
+
+    std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const std::string& password, int timeoutMS, const std::atomic<bool>* cancellation) {
+        return std::make_shared<Client>(net::connect(host, port, timeoutMS), out, password, cancellation);
     }
 
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey) {
@@ -578,6 +601,10 @@ namespace server {
     }
 
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey, int timeoutMS) {
-        return std::make_shared<Client>(net::connect(host, port, timeoutMS), out, authKey);
+        return connect(std::move(host), port, out, authKey, timeoutMS, nullptr);
+    }
+
+    std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey, int timeoutMS, const std::atomic<bool>* cancellation) {
+        return std::make_shared<Client>(net::connect(host, port, timeoutMS), out, authKey, cancellation);
     }
 }

--- a/source_modules/sdrpp_server_source/src/sdrpp_server_client.cpp
+++ b/source_modules/sdrpp_server_source/src/sdrpp_server_client.cpp
@@ -566,10 +566,18 @@ namespace server {
     }
 
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const std::string& password) {
-        return std::make_shared<Client>(net::connect(host, port), out, password);
+        return connect(std::move(host), port, out, password, net::NO_TIMEOUT);
+    }
+
+    std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const std::string& password, int timeoutMS) {
+        return std::make_shared<Client>(net::connect(host, port, timeoutMS), out, password);
     }
 
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey) {
-        return std::make_shared<Client>(net::connect(host, port), out, authKey);
+        return connect(std::move(host), port, out, authKey, net::NO_TIMEOUT);
+    }
+
+    std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey, int timeoutMS) {
+        return std::make_shared<Client>(net::connect(host, port, timeoutMS), out, authKey);
     }
 }

--- a/source_modules/sdrpp_server_source/src/sdrpp_server_client.h
+++ b/source_modules/sdrpp_server_source/src/sdrpp_server_client.h
@@ -2,6 +2,7 @@
 #include <utils/net.h>
 #include <dsp/stream.h>
 #include <dsp/types.h>
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <queue>
@@ -32,9 +33,17 @@ namespace server {
     class PacketWaiter {
     public:
         // Returns true if the ACK arrived, false on timeout or cancel.
-        bool await(int timeout) {
+        bool await(int timeout, const std::atomic<bool>* cancellation = nullptr) {
             std::unique_lock lck(mtx);
-            return cnd.wait_for(lck, std::chrono::milliseconds(timeout), [this]() { return dataReady || canceled; }) && dataReady && !canceled;
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
+            while (!dataReady && !canceled) {
+                if (cancellation && cancellation->load()) { return false; }
+                const auto now = std::chrono::steady_clock::now();
+                if (now >= deadline) { return false; }
+                const auto pollDeadline = std::min(deadline, now + std::chrono::milliseconds(50));
+                cnd.wait_until(lck, pollDeadline, [this]() { return dataReady || canceled; });
+            }
+            return dataReady && !canceled;
         }
 
         // Worker thread: copy the ACK payload into the waiter and wake the
@@ -74,7 +83,8 @@ namespace server {
         CONN_ERR_TIMEOUT    = -1,
         CONN_ERR_BUSY       = -2,
         CONN_ERR_PROTOCOL   = -3,
-        CONN_ERR_AUTH       = -4
+        CONN_ERR_AUTH       = -4,
+        CONN_ERR_CANCELLED  = -5
     };
 
     class Client {
@@ -86,7 +96,9 @@ namespace server {
         };
 
         Client(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const std::string& password);
+        Client(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const std::string& password, const std::atomic<bool>* cancellation);
         Client(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey);
+        Client(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey, const std::atomic<bool>* cancellation);
         ~Client();
 
         void showMenu();
@@ -116,13 +128,13 @@ namespace server {
         std::atomic<bool> protocolReady{false};
 
     private:
-        void init(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const AuthKey* authKey);
+        void init(std::shared_ptr<net::Socket> sock, dsp::stream<dsp::complex_t>* out, const AuthKey* authKey, const std::atomic<bool>* cancellation);
         void worker();
         void applyRxPrebufferModeLocked(bool resetBuffer);
 
-        int hello(const AuthKey* authKey);
-        int authenticate(const AuthKey& authKey);
-        int getUI();
+        int hello(const AuthKey* authKey, const std::atomic<bool>* cancellation);
+        int authenticate(const AuthKey& authKey, const std::atomic<bool>* cancellation);
+        int getUI(const std::atomic<bool>* cancellation = nullptr);
 
         void sendPacketLocked(PacketType type, int len);
         void sendCommandLocked(Command cmd, int len);
@@ -193,6 +205,8 @@ namespace server {
 
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const std::string& password = "");
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const std::string& password, int timeoutMS);
+    std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const std::string& password, int timeoutMS, const std::atomic<bool>* cancellation);
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey);
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey, int timeoutMS);
+    std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey, int timeoutMS, const std::atomic<bool>* cancellation);
 }

--- a/source_modules/sdrpp_server_source/src/sdrpp_server_client.h
+++ b/source_modules/sdrpp_server_source/src/sdrpp_server_client.h
@@ -192,5 +192,7 @@ namespace server {
     };
 
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const std::string& password = "");
+    std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const std::string& password, int timeoutMS);
     std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey);
+    std::shared_ptr<Client> connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, const AuthKey& authKey, int timeoutMS);
 }

--- a/source_modules/spyserver_source/src/main.cpp
+++ b/source_modules/spyserver_source/src/main.cpp
@@ -9,6 +9,9 @@
 #include <config.h>
 #include <gui/widgets/stepped_slider.h>
 #include <gui/smgui.h>
+#include <atomic>
+#include <mutex>
+#include <thread>
 
 
 #define CONCAT(a, b) ((std::string(a) + b).c_str())
@@ -72,6 +75,9 @@ public:
 
     ~SpyServerSourceModule() {
         stop(this);
+        if (connectionThread.joinable()) {
+            connectionThread.join();
+        }
         sigpath::sourceManager.unregisterSource("SpyServer");
     }
 
@@ -162,6 +168,8 @@ private:
     static void menuHandler(void* ctx) {
         SpyServerSourceModule* _this = (SpyServerSourceModule*)ctx;
 
+        _this->pollConnection();
+
         bool connected = (_this->client && _this->client->isOpen());
         gui::mainWindow.playButtonLocked = !connected;
 
@@ -183,12 +191,19 @@ private:
         if (_this->running) { SmGui::BeginDisabled(); }
         SmGui::FillWidth();
         SmGui::ForceSync();
+        // Keep this value for the whole ImGui scope. tryConnect() changes the
+        // atomic immediately; testing it again below would call EndDisabled()
+        // without the matching BeginDisabled() in the frame where Connect was
+        // clicked, corrupting ImGui's style stack.
+        const bool connecting = _this->connecting.load();
+        if (connecting) { SmGui::BeginDisabled(); }
         if (!connected && SmGui::Button("Connect##spyserver_source")) {
             _this->tryConnect();
         }
         else if (connected && SmGui::Button("Disconnect##spyserver_source")) {
             _this->client->close();
         }
+        if (connecting) { SmGui::EndDisabled(); }
         if (_this->running) { SmGui::EndDisabled(); }
 
 
@@ -236,56 +251,100 @@ private:
         else {
             SmGui::Text("Status:");
             SmGui::SameLine();
-            SmGui::Text("Not connected");
+            SmGui::Text(_this->connecting ? "Connecting..." : "Not connected");
+            if (!_this->connecting && !_this->lastConnectionError.empty()) {
+                SmGui::TextColoredF(ImVec4(1.0f, 0.35f, 0.35f, 1.0f), "Connection failed: %s", _this->lastConnectionError.c_str());
+            }
         }
     }
 
     void tryConnect() {
-        try {
-            if (client) { client.reset(); }
-            client = spyserver::connect(hostname, port, &stream);
+        if (connecting.exchange(true)) { return; }
 
-            if (!client->waitForDevInfo(3000)) {
-                flog::error("SpyServer didn't respond with device information");
-            }
-            else {
-                char buf[1024];
-                sprintf(buf, "%s [%08X]", deviceTypesStr[client->devInfo.DeviceType], client->devInfo.DeviceSerial);
-                devRef = std::string(buf);
+        if (connectionThread.joinable()) {
+            connectionThread.join();
+        }
+        if (client) { client.reset(); }
+        {
+            std::lock_guard lck(connectionMtx);
+            connectionError.clear();
+        }
+        lastConnectionError.clear();
 
-                config.acquire();
-                if (!config.conf["devices"].contains(devRef)) {
-                    config.conf["devices"][devRef]["sampleRateId"] = 0;
-                    config.conf["devices"][devRef]["sampleBitDepthId"] = 1;
-                    config.conf["devices"][devRef]["gainId"] = 0;
-                }
-                srId = config.conf["devices"][devRef]["sampleRateId"];
-                iqType = config.conf["devices"][devRef]["sampleBitDepthId"];
-                gain = config.conf["devices"][devRef]["gainId"];
-                config.release(true);
-
-                gain = std::clamp<int>(gain, 0, client->devInfo.MaximumGainIndex);
-
-                // Refresh sample rates
-                sampleRates.clear();
-                sampleRatesTxt.clear();
-                for (int i = client->devInfo.MinimumIQDecimation; i <= client->devInfo.DecimationStageCount; i++) {
-                    double sr = (double)client->devInfo.MaximumSampleRate / ((double)(1 << i));
-                    sampleRates.push_back(sr);
-                    sampleRatesTxt += getBandwdithScaled(sr);
-                    sampleRatesTxt += '\0';
+        const std::string host = hostname;
+        const uint16_t targetPort = port;
+        connectionThread = std::thread([this, host, targetPort]() {
+            try {
+                auto newClient = spyserver::connect(host, targetPort, &stream);
+                if (!newClient->waitForDevInfo(3000)) {
+                    newClient->close();
+                    throw std::runtime_error("SpyServer didn't respond with device information");
                 }
 
-                srId = std::clamp<int>(srId, 0, sampleRates.size() - 1);
-
-                sampleRate = sampleRates[srId];
-                core::setInputSampleRate(sampleRate);
-                flog::info("Connected to server");
+                std::lock_guard lck(connectionMtx);
+                pendingClient = std::move(newClient);
             }
+            catch (const std::exception& e) {
+                std::lock_guard lck(connectionMtx);
+                connectionError = e.what();
+            }
+            connecting = false;
+        });
+    }
+
+    void pollConnection() {
+        if (connecting || !connectionThread.joinable()) { return; }
+
+        connectionThread.join();
+
+        spyserver::SpyServerClient newClient;
+        std::string error;
+        {
+            std::lock_guard lck(connectionMtx);
+            newClient = std::move(pendingClient);
+            error = std::move(connectionError);
         }
-        catch (const std::exception& e) {
-            flog::error("Could not connect to spyserver {}", e.what());
+        if (!newClient) {
+            if (!error.empty()) {
+                flog::error("Could not connect to spyserver {}", error);
+                lastConnectionError = std::move(error);
+            }
+            return;
         }
+
+        client = std::move(newClient);
+        char buf[1024];
+        sprintf(buf, "%s [%08X]", deviceTypesStr[client->devInfo.DeviceType], client->devInfo.DeviceSerial);
+        devRef = std::string(buf);
+
+        config.acquire();
+        if (!config.conf["devices"].contains(devRef)) {
+            config.conf["devices"][devRef]["sampleRateId"] = 0;
+            config.conf["devices"][devRef]["sampleBitDepthId"] = 1;
+            config.conf["devices"][devRef]["gainId"] = 0;
+        }
+        srId = config.conf["devices"][devRef]["sampleRateId"];
+        iqType = config.conf["devices"][devRef]["sampleBitDepthId"];
+        gain = config.conf["devices"][devRef]["gainId"];
+        config.release(true);
+
+        gain = std::clamp<int>(gain, 0, client->devInfo.MaximumGainIndex);
+
+        // Refresh sample rates on the GUI thread, where the source state is used.
+        sampleRates.clear();
+        sampleRatesTxt.clear();
+        for (int i = client->devInfo.MinimumIQDecimation; i <= client->devInfo.DecimationStageCount; i++) {
+            double sr = (double)client->devInfo.MaximumSampleRate / ((double)(1 << i));
+            sampleRates.push_back(sr);
+            sampleRatesTxt += getBandwdithScaled(sr);
+            sampleRatesTxt += '\0';
+        }
+
+        srId = std::clamp<int>(srId, 0, sampleRates.size() - 1);
+
+        sampleRate = sampleRates[srId];
+        core::setInputSampleRate(sampleRate);
+        flog::info("Connected to server");
     }
 
     std::string name;
@@ -310,6 +369,12 @@ private:
     SourceManager::SourceHandler handler;
 
     spyserver::SpyServerClient client;
+    spyserver::SpyServerClient pendingClient;
+    std::thread connectionThread;
+    std::mutex connectionMtx;
+    std::string connectionError;
+    std::string lastConnectionError;
+    std::atomic<bool> connecting{false};
 };
 
 MOD_EXPORT void _INIT_() {

--- a/source_modules/spyserver_source/src/main.cpp
+++ b/source_modules/spyserver_source/src/main.cpp
@@ -75,6 +75,7 @@ public:
 
     ~SpyServerSourceModule() {
         stop(this);
+        cancelConnection();
         if (connectionThread.joinable()) {
             connectionThread.join();
         }
@@ -119,6 +120,7 @@ private:
 
     static void menuDeselected(void* ctx) {
         SpyServerSourceModule* _this = (SpyServerSourceModule*)ctx;
+        _this->cancelConnection();
         gui::mainWindow.playButtonLocked = false;
         flog::info("SpyServerSourceModule '{0}': Menu Deselect!", _this->name);
     }
@@ -173,7 +175,8 @@ private:
         bool connected = (_this->client && _this->client->isOpen());
         gui::mainWindow.playButtonLocked = !connected;
 
-        if (connected) { SmGui::BeginDisabled(); }
+        const bool connecting = _this->connecting.load();
+        if (connected || connecting) { SmGui::BeginDisabled(); }
         if (SmGui::InputText(CONCAT("##_spyserver_srv_host_", _this->name), _this->hostname, 1023)) {
             config.acquire();
             config.conf["hostname"] = _this->hostname;
@@ -186,7 +189,7 @@ private:
             config.conf["port"] = _this->port;
             config.release(true);
         }
-        if (connected) { SmGui::EndDisabled(); }
+        if (connected || connecting) { SmGui::EndDisabled(); }
 
         if (_this->running) { SmGui::BeginDisabled(); }
         SmGui::FillWidth();
@@ -195,7 +198,6 @@ private:
         // atomic immediately; testing it again below would call EndDisabled()
         // without the matching BeginDisabled() in the frame where Connect was
         // clicked, corrupting ImGui's style stack.
-        const bool connecting = _this->connecting.load();
         if (connecting) { SmGui::BeginDisabled(); }
         if (!connected && SmGui::Button("Connect##spyserver_source")) {
             _this->tryConnect();
@@ -261,9 +263,16 @@ private:
     void tryConnect() {
         if (connecting.exchange(true)) { return; }
 
+        if (port <= 0 || port > 65535) {
+            lastConnectionError = "Port must be between 1 and 65535";
+            connecting = false;
+            return;
+        }
+
         if (connectionThread.joinable()) {
             connectionThread.join();
         }
+        connectionCancelled = false;
         if (client) { client.reset(); }
         {
             std::lock_guard lck(connectionMtx);
@@ -273,23 +282,56 @@ private:
 
         const std::string host = hostname;
         const uint16_t targetPort = port;
-        connectionThread = std::thread([this, host, targetPort]() {
-            try {
-                auto newClient = spyserver::connect(host, targetPort, &stream);
-                if (!newClient->waitForDevInfo(3000)) {
-                    newClient->close();
-                    throw std::runtime_error("SpyServer didn't respond with device information");
-                }
+        try {
+            connectionThread = std::thread([this, host, targetPort]() {
+                try {
+                    auto newClient = spyserver::connect(host, targetPort, &stream, 3000);
+                    if (!newClient->waitForDevInfo(3000)) {
+                        newClient->close();
+                        throw std::runtime_error("SpyServer didn't respond with device information");
+                    }
 
-                std::lock_guard lck(connectionMtx);
-                pendingClient = std::move(newClient);
-            }
-            catch (const std::exception& e) {
-                std::lock_guard lck(connectionMtx);
-                connectionError = e.what();
-            }
+                    bool discard = false;
+                    {
+                        std::lock_guard lck(connectionMtx);
+                        discard = connectionCancelled.load();
+                        if (!discard) {
+                            pendingClient = std::move(newClient);
+                        }
+                    }
+                    if (discard) {
+                        newClient->close();
+                    }
+                }
+                catch (const std::exception& e) {
+                    if (!connectionCancelled) {
+                        std::lock_guard lck(connectionMtx);
+                        connectionError = e.what();
+                    }
+                }
+                connecting = false;
+            });
+        }
+        catch (const std::exception& e) {
             connecting = false;
-        });
+            lastConnectionError = std::string("Could not start connection worker: ") + e.what();
+            flog::error("{}", lastConnectionError);
+        }
+    }
+
+    void cancelConnection() {
+        connectionCancelled = true;
+
+        spyserver::SpyServerClient abandonedClient;
+        {
+            std::lock_guard lck(connectionMtx);
+            abandonedClient = std::move(pendingClient);
+            connectionError.clear();
+        }
+        if (abandonedClient) {
+            abandonedClient->close();
+        }
+        lastConnectionError.clear();
     }
 
     void pollConnection() {
@@ -297,12 +339,19 @@ private:
 
         connectionThread.join();
 
+        const bool cancelled = connectionCancelled.exchange(false);
         spyserver::SpyServerClient newClient;
         std::string error;
         {
             std::lock_guard lck(connectionMtx);
             newClient = std::move(pendingClient);
             error = std::move(connectionError);
+        }
+        if (cancelled) {
+            if (newClient) {
+                newClient->close();
+            }
+            return;
         }
         if (!newClient) {
             if (!error.empty()) {
@@ -312,39 +361,66 @@ private:
             return;
         }
 
-        client = std::move(newClient);
-        char buf[1024];
-        sprintf(buf, "%s [%08X]", deviceTypesStr[client->devInfo.DeviceType], client->devInfo.DeviceSerial);
-        devRef = std::string(buf);
+        try {
+            constexpr uint32_t DEVICE_TYPE_COUNT = sizeof(deviceTypesStr) / sizeof(deviceTypesStr[0]);
+            if (newClient->devInfo.DeviceType >= DEVICE_TYPE_COUNT) {
+                throw std::runtime_error("SpyServer reported an unsupported device type");
+            }
+            if (newClient->devInfo.MinimumIQDecimation > newClient->devInfo.DecimationStageCount ||
+                newClient->devInfo.DecimationStageCount >= 31 ||
+                newClient->devInfo.MaximumSampleRate == 0) {
+                throw std::runtime_error("SpyServer reported invalid sample-rate metadata");
+            }
 
-        config.acquire();
-        if (!config.conf["devices"].contains(devRef)) {
-            config.conf["devices"][devRef]["sampleRateId"] = 0;
-            config.conf["devices"][devRef]["sampleBitDepthId"] = 1;
-            config.conf["devices"][devRef]["gainId"] = 0;
+            client = std::move(newClient);
+            char buf[1024];
+            snprintf(buf, sizeof(buf), "%s [%08X]", deviceTypesStr[client->devInfo.DeviceType], client->devInfo.DeviceSerial);
+            devRef = std::string(buf);
+
+            config.acquire();
+            try {
+                if (!config.conf["devices"].contains(devRef)) {
+                    config.conf["devices"][devRef]["sampleRateId"] = 0;
+                    config.conf["devices"][devRef]["sampleBitDepthId"] = 1;
+                    config.conf["devices"][devRef]["gainId"] = 0;
+                }
+                srId = config.conf["devices"][devRef]["sampleRateId"];
+                iqType = config.conf["devices"][devRef]["sampleBitDepthId"];
+                gain = config.conf["devices"][devRef]["gainId"];
+                config.release(true);
+            }
+            catch (...) {
+                config.release();
+                throw;
+            }
+
+            gain = std::clamp<int>(gain, 0, client->devInfo.MaximumGainIndex);
+
+            // Refresh sample rates on the GUI thread, where the source state is used.
+            sampleRates.clear();
+            sampleRatesTxt.clear();
+            for (int i = client->devInfo.MinimumIQDecimation; i <= client->devInfo.DecimationStageCount; i++) {
+                double sr = (double)client->devInfo.MaximumSampleRate / ((double)(1U << i));
+                sampleRates.push_back(sr);
+                sampleRatesTxt += getBandwdithScaled(sr);
+                sampleRatesTxt += '\0';
+            }
+
+            srId = std::clamp<int>(srId, 0, (int)sampleRates.size() - 1);
+            iqType = std::clamp<int>(iqType, 0, (int)(sizeof(streamFormats) / sizeof(streamFormats[0])) - 1);
+
+            sampleRate = sampleRates[srId];
+            core::setInputSampleRate(sampleRate);
+            flog::info("Connected to server");
         }
-        srId = config.conf["devices"][devRef]["sampleRateId"];
-        iqType = config.conf["devices"][devRef]["sampleBitDepthId"];
-        gain = config.conf["devices"][devRef]["gainId"];
-        config.release(true);
-
-        gain = std::clamp<int>(gain, 0, client->devInfo.MaximumGainIndex);
-
-        // Refresh sample rates on the GUI thread, where the source state is used.
-        sampleRates.clear();
-        sampleRatesTxt.clear();
-        for (int i = client->devInfo.MinimumIQDecimation; i <= client->devInfo.DecimationStageCount; i++) {
-            double sr = (double)client->devInfo.MaximumSampleRate / ((double)(1 << i));
-            sampleRates.push_back(sr);
-            sampleRatesTxt += getBandwdithScaled(sr);
-            sampleRatesTxt += '\0';
+        catch (const std::exception& e) {
+            flog::error("Could not initialize SpyServer connection: {}", e.what());
+            lastConnectionError = e.what();
+            if (client) {
+                client->close();
+                client.reset();
+            }
         }
-
-        srId = std::clamp<int>(srId, 0, sampleRates.size() - 1);
-
-        sampleRate = sampleRates[srId];
-        core::setInputSampleRate(sampleRate);
-        flog::info("Connected to server");
     }
 
     std::string name;
@@ -375,6 +451,7 @@ private:
     std::string connectionError;
     std::string lastConnectionError;
     std::atomic<bool> connecting{false};
+    std::atomic<bool> connectionCancelled{false};
 };
 
 MOD_EXPORT void _INIT_() {

--- a/source_modules/spyserver_source/src/spyserver_client.cpp
+++ b/source_modules/spyserver_source/src/spyserver_client.cpp
@@ -164,7 +164,11 @@ namespace spyserver {
     }
 
     SpyServerClient connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out) {
-        net::Conn conn = net::connect(host, port);
+        return connect(std::move(host), port, out, -1);
+    }
+
+    SpyServerClient connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, int timeoutMS) {
+        net::Conn conn = net::connect(host, port, timeoutMS);
         if (!conn) {
             return NULL;
         }

--- a/source_modules/spyserver_source/src/spyserver_client.h
+++ b/source_modules/spyserver_source/src/spyserver_client.h
@@ -49,5 +49,6 @@ namespace spyserver {
     typedef std::unique_ptr<SpyServerClientClass> SpyServerClient;
 
     SpyServerClient connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out);
+    SpyServerClient connect(std::string host, uint16_t port, dsp::stream<dsp::complex_t>* out, int timeoutMS);
 
 }


### PR DESCRIPTION
Closes #19.

## Summary

- move SpyServer and SDR++ Server connection setup off the GUI thread
- add explicit timed DNS/TCP connect overloads while preserving the existing blocking overloads
- bound timed DNS resolution to one shared process-lifetime worker and remove expired queued requests
- make SDR++ protocol initialization cancellation-aware, including HELLO, authentication, and remote UI synchronization
- cancel or discard pending clients when a source is deselected and join workers safely during teardown
- show actionable connection failures in both source panels
- keep ImGui begin/end state balanced on all connection states and validate SpyServer metadata before using it
- harden SDR++ ACK waiter ownership and server-pushed state synchronization encountered while exercising failed and interrupted connections

## Verification

- complete macOS build and `stage_macos_bundle` target
- successful localhost connections through both core network APIs
- refused localhost port reports immediately
- `92.26.30.159:5555` reports `Connection timed out` after approximately 3.0 seconds
- invalid DNS reports a resolver error
- incomplete SDR++ protocol handshake cancels in approximately 270 ms instead of waiting through multiple 10-second protocol timeouts
- ten simulated DNS timeouts use one resolver worker
- `git diff --check` passes
- existing and new timed network overload symbols are exported

The repository currently registers no CTest tests, so the network and cancellation cases were exercised with standalone local probes. The macOS staging result is ad-hoc signed by the existing script; this PR does not add Developer ID signing or notarization.